### PR TITLE
index

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ import { useWebSocket } from '@/components/providers/WebSocketProvider';
 import { Switch } from '@/components/ui/switch';
 import Spinner from '@/components/ui/Spinner';
 
-const TOKENS_PER_PAGE = 10;
+const TOKENS_PER_PAGE = 12;
 
 const Home: React.FC = () => {
   const [tokens, setTokens] = useState<PaginatedResponse<Token | TokenWithLiquidityEvents> | null>(null);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -7,7 +7,7 @@ import { ethers } from 'ethers';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export async function getAllTokens(page: number = 1, pageSize: number = 20): Promise<PaginatedResponse<Token>> {
+export async function getAllTokens(page: number = 1, pageSize: number = 13): Promise<PaginatedResponse<Token>> {
   const response = await axios.get(`${API_BASE_URL}/api/tokens`, {
     params: { page, pageSize }
   });


### PR DESCRIPTION
## Summary by Sourcery

Update pagination settings to display more tokens per page on the home page and adjust the API's default page size for token retrieval.

Enhancements:
- Increase the number of tokens displayed per page from 10 to 12 on the home page.
- Adjust the default page size for fetching tokens from the API from 20 to 13.